### PR TITLE
Fix comment and bracket config

### DIFF
--- a/smali.configuration.json
+++ b/smali.configuration.json
@@ -1,14 +1,10 @@
 {
 	"comments": {
-		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
-		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-		"blockComment": [ "/*", "*/" ]
+		"lineComment": "#"
 	},
 	// symbols used as brackets
 	"brackets": [
 		["{", "}"],
-		["[", "]"],
 		["(", ")"]
 	]
 }


### PR DESCRIPTION
Smali comments are `#`-prefixed and from what little I know `[` is used for "non-parenthetical purposes"—I'm not quite sure what.